### PR TITLE
Fixed absolute path issue on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
           "first before install pymatgen...")
     sys.exit(-1)
 
-SETUP_PTH = os.path.dirname(os.path.abspath(__file__))
+SETUP_PTH = os.path.dirname(__file__)
 
 
 with open(os.path.join(SETUP_PTH, "README.rst")) as f:


### PR DESCRIPTION
## Summary

Removed os.path.abspath because this was preventing installation from the extracted tar.gz source when running setup.py install under Windows OS (not sure if it manifests on Linux). The setup() function should only need relative paths. 
## Note

Please test this under Mac OS X / Linux to confirm the changes do not impact installation on these systems.

Thanks and kind regards,

Liam Deacon
